### PR TITLE
Reset controllers between simulation runs

### DIFF
--- a/src/run_simulation.py
+++ b/src/run_simulation.py
@@ -116,8 +116,10 @@ def main():
     rows = []
     for ctrl_name in args.controllers:
         print(f"[+] controller: {ctrl_name}")
-        ctrl = load_controller(ctrl_name, trace, args.model_coeffs)
         for run in range(args.runs):
+            # instantiate a fresh controller for each run so that internal state
+            # from previous simulations does not leak across repetitions
+            ctrl = load_controller(ctrl_name, trace, args.model_coeffs)
             sim  = Cluster(trace, ctrl)
             summ = sim.run()
             summ.update(controller=ctrl_name, run=run)


### PR DESCRIPTION
## Summary
- re-instantiate controllers for every simulation run so state doesn't leak across repetitions

## Testing
- `python src/run_simulation.py --workload synthetic_trace.csv --controllers reactive --runs 2 --plot-file ""`


------
https://chatgpt.com/codex/tasks/task_e_689020502ae88327802eeaa2fc538abf