### PR TITLE
Fix predictive controllers to provision cores directly

### DIFF
--- a/src/controllers/hybrid.py
+++ b/src/controllers/hybrid.py
@@ -1,10 +1,13 @@
+import math
+
+
 class Hybrid:
-    CPU_PER_VM = 4
     def __init__(self, hourly_fc, alpha=0.7, low=0.4, high=0.8):
         self.fc, self.alpha, self.low, self.high = hourly_fc, alpha, low, high
+
     def update(self, t, cores, served, q):
         hour = t // 3600
-        pred_core = max(1, int(self.fc[hour] // self.CPU_PER_VM))
+        pred_core = int(math.ceil(self.fc[hour] + q))
         util = served / cores if cores else 0
         reactive = int(cores * 1.1) if util > self.high else \
                    int(cores * 0.9) if util < self.low else cores

--- a/src/controllers/predictive_arima.py
+++ b/src/controllers/predictive_arima.py
@@ -1,15 +1,29 @@
+import math
 import numpy as np
 from collections import deque
 from statsmodels.tsa.arima.model import ARIMA
+
+
 class PredictiveARIMA:
-    CPU_PER_VM, STEP, WIN = 4, 60, 1800
+    STEP, WIN = 60, 1800
+
     def __init__(self):
-        self.buf, self.next_t, self.pred = deque(maxlen=self.WIN), 0, 1
+        self.buf = deque(maxlen=self.WIN)
+        self.next_t = 0
+        self.pred = 1.0
+        self.prev_q = 0
+
     def update(self, t, cores, served, q):
-        self.buf.append(served)
+        # approximate true incoming load = served + delta(queue)
+        load = served + max(0, q - self.prev_q)
+        self.buf.append(load)
+        self.prev_q = q
         if t >= self.next_t and len(self.buf) >= 300:
             arr = np.array(self.buf, float)
-            try:  self.pred = ARIMA(arr, order=(1,0,1)).fit(disp=False).forecast()[0]
-            except: self.pred = arr.mean()
+            try:
+                self.pred = ARIMA(arr, order=(1, 0, 1)).fit(disp=False).forecast()[0]
+            except Exception:
+                self.pred = arr.mean()
             self.next_t = t + self.STEP
-        return max(1, int(max(1.0, self.pred) // self.CPU_PER_VM))
+        # provision in cores for predicted load plus any backlog
+        return max(1, int(math.ceil(self.pred + q)))

--- a/src/controllers/predictive_hourly.py
+++ b/src/controllers/predictive_hourly.py
@@ -1,7 +1,12 @@
+import math
+
+
 class PredictiveHourly:
-    CPU_PER_VM = 4
     def __init__(self, hourly_forecast):       # 24-value array
         self.fc = hourly_forecast
+
     def update(self, t, cores, served, q):
         hour = t // 3600
-        return max(1, int(self.fc[hour] // self.CPU_PER_VM))
+        # scale provision directly in cores (1 core ~= 1 req/sec) and account for
+        # any queued backlog to avoid SLA violations
+        return max(1, int(math.ceil(self.fc[hour] + q)))

--- a/src/controllers/predictive_ml.py
+++ b/src/controllers/predictive_ml.py
@@ -1,11 +1,21 @@
-import json, pathlib
+import json
+import math
+import pathlib
 from dataclasses import dataclass
+
+
 @dataclass
 class PredictiveML:
-    a: float; b: float; cpu_per_vm: int = 4
+    a: float
+    b: float
+    cpu_per_vm: int = 4  # retained for backwards compatibility
+
     def update(self, t, cores, served, q):
         pred = max(1.0, self.a * (t + 1) + self.b)
-        return max(1, int(pred // self.cpu_per_vm))
+        # predict core demand directly and include backlog to reduce latency
+        return max(1, int(math.ceil(pred + q)))
+
+
 def load_from_json(path):
     coeffs = json.loads(pathlib.Path(path).read_text())
     return PredictiveML(a=coeffs["a"], b=coeffs["b"],


### PR DESCRIPTION
## Summary
- correct predictive controllers to provision in cores rather than VMs and include queue backlog
- improve ARIMA-based controller by learning from true demand instead of served load

## Testing
- `python test_data_gen.py --outfile trace.csv`
- `python src/train_linear_model.py --trace trace.csv --mode single --outfile linear_model.json`
- `python src/run_simulation.py --workload trace.csv --controllers reactive predictive_hourly predictive_arima predictive_ml hybrid --model-coeffs linear_model.json --runs 1 --outfile results.csv --plot-file ""`


------
https://chatgpt.com/codex/tasks/task_e_689021a99fd483279cdcade139c821d4